### PR TITLE
Added support to schools.studentsLeaver

### DIFF
--- a/src/DotNetClient/DotNetClient/Wonde/EndPoints/Schools.cs
+++ b/src/DotNetClient/DotNetClient/Wonde/EndPoints/Schools.cs
@@ -138,6 +138,11 @@ namespace Wonde.EndPoints
         public Events events;
 
         /// <summary>
+        /// Object of Students Leaver
+        /// </summary>
+        public StudentsLeaver studentsLeaver;
+
+        /// <summary>
         /// Constructor 
         /// </summary>
         /// <param name="token">Api Token</param>
@@ -187,6 +192,7 @@ namespace Wonde.EndPoints
                 rooms = new Rooms(token, Uri);
                 students = new Students(token, Uri);
                 subjects = new Subjects(token, Uri);
+                studentsLeaver = new StudentsLeaver(token, Uri);
             }
 
         }

--- a/src/DotNetClient/DotNetClient/Wonde/EndPoints/StudentsLeaver.cs
+++ b/src/DotNetClient/DotNetClient/Wonde/EndPoints/StudentsLeaver.cs
@@ -1,0 +1,15 @@
+﻿namespace Wonde.EndPoints
+{
+    public class StudentsLeaver : BootstrapEndpoint
+    {
+        /// <summary>
+        /// Internal Constructor so object can only be retrieved through Wonde.Endpoints.Schools object
+        /// </summary>
+        /// <param name="token">Api Token</param>
+        /// <param name="url">Url to set</param>
+        internal StudentsLeaver(string token, string url) : base(token, url)
+        {
+            Uri = Uri + "students-leaver/";
+        }
+    }
+}


### PR DESCRIPTION
Description

Added support to student leavers.
Can be accessed by 
`school.studentsLeaver.all()`


Security risk
High

Type of change
New feature

How has this been tested?
Tested by running some tests. I tried accessing leavers data using Wonde.NET client.
![image](https://user-images.githubusercontent.com/84071411/132849610-c16db58b-76bc-4dae-a981-605a0ee42813.png)

![image](https://user-images.githubusercontent.com/84071411/132849547-ce68c97a-a0b0-43a3-b68f-7e30573a5e34.png)

OWASP checklist

    Injection √
    Broken Authentication √
    Sensitive Data Exposure √
    XML External Entities (XXE) √
    Broken Access control √
    Security misconfigurations √
    Cross Site Scripting (XSS) √
    Insecure Deserialisation √
    Using Components with known vulnerabilities √
    Insufficient logging and monitoring √

Rollout plan

Rollback the PR merge to rollback.
Third-party libraries

This PR does not introduce any new third-party libraries.